### PR TITLE
[sogoagain/blog#71] Hero 문자열 Scramble 효과가 이어지도록 수정

### DIFF
--- a/src/components/posts/Comment.jsx
+++ b/src/components/posts/Comment.jsx
@@ -1,7 +1,7 @@
-import React, { createRef, useEffect } from "react";
+import React, { useRef, useEffect } from "react";
 
 export default function Comment({ utterances }) {
-  const ref = createRef();
+  const ref = useRef(null);
 
   useEffect(() => {
     const scriptEl = document.createElement("script");

--- a/src/hooks/useScrambleTexts.js
+++ b/src/hooks/useScrambleTexts.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, createRef } from "react";
+import { useState, useEffect, useRef } from "react";
 
 import { shuffleArray } from "../utils";
 
@@ -7,8 +7,8 @@ export default function useScrambleTexts(texts) {
   const [index, setIndex] = useState(0);
   const [scrambledText, setScrambledText] = useState(queue[index]);
 
-  const scramblerRef = createRef();
-  const timeoutRef = createRef();
+  const scramblerRef = useRef(null);
+  const timeoutRef = useRef(null);
 
   useEffect(async () => {
     if (!scramblerRef.current) {

--- a/src/hooks/useScrambleTexts.js
+++ b/src/hooks/useScrambleTexts.js
@@ -29,7 +29,7 @@ export default function useScrambleTexts(texts) {
       } else {
         setIndex(index + 1);
       }
-    }, 2500);
+    }, 3000);
   }, [index]);
 
   useEffect(() => {


### PR DESCRIPTION
## 변경사항

<!-- 변경사항을 간략히 기술합니다. -->

- Hero 문자열 Scramble 효과가 이어지도록 수정
- createRef는 class 컴포넌트에서 사용하는 것으로 함수 컴포넌트에서는 useRef를 사용해야 한다.

## 이슈

<!-- PR과 관련된 이슈 링크를 작성합니다. -->

- https://github.com/sogoagain/blog/issues/

## 회고

<!-- PR을 회고합니다. -->

- [x] 코드를 다시 한번 살펴보았나요?
