### PR TITLE
[sogoagain/blog#93] 태그 목록 정렬시 totalCount가 동일하면 한국어 기준으로 정렬한다

### DIFF
--- a/src/__fixtures__/tagsQuery.js
+++ b/src/__fixtures__/tagsQuery.js
@@ -17,6 +17,10 @@ const tagsQeury = {
         tag: "Git",
         totalCount: 4,
       },
+      {
+        tag: "설정",
+        totalCount: 2,
+      },
     ],
   },
 };

--- a/src/container/TagListContainer.jsx
+++ b/src/container/TagListContainer.jsx
@@ -35,7 +35,9 @@ export default function TagListContainer() {
   const tags = group
     .sort((a, b) => {
       const totalCountDiff = b.totalCount - a.totalCount;
-      return totalCountDiff === 0 ? a.tag.localeCompare(b.tag) : totalCountDiff;
+      return totalCountDiff === 0
+        ? a.tag.localeCompare(b.tag, "ko")
+        : totalCountDiff;
     })
     .flatMap((item) => item.tag.trim());
 

--- a/src/container/TagListContainer.test.jsx
+++ b/src/container/TagListContainer.test.jsx
@@ -18,17 +18,17 @@ describe("<TagListContainer/>", () => {
   });
 
   it("태그 목록을 출력한다", () => {
-    ["C++", "DB", "Docker", "Git"].forEach((tag) => {
+    ["설정", "C++", "DB", "Docker", "Git"].forEach((tag) => {
       const tagEl = screen.getByText(tag);
 
       expect(tagEl).toBeInTheDocument();
     });
   });
 
-  it("태그 목록이 totalCount 기준으로 내림차순 정렬되어 출력된다", () => {
+  it("태그 목록이 totalCount 기준으로 내림차순, totalCount가 동일하면 한국어 기준 정렬되어 출력된다", () => {
     const tags = screen.getAllByText(/.+/).map((label) => label.textContent);
 
-    const sortedTags = ["Git", "C++", "DB", "Docker"];
+    const sortedTags = ["Git", "설정", "C++", "DB", "Docker"];
 
     expect(tags).toEqual(sortedTags);
   });
@@ -38,28 +38,40 @@ describe("<TagListContainer/>", () => {
     const tag2 = screen.getByText("DB");
     const tag3 = screen.getByText("Docker");
     const tag4 = screen.getByText("Git");
+    const tag5 = screen.getByText("설정");
 
     expect(tag1.closest("label").querySelector("input")).not.toBeChecked();
     expect(tag2.closest("label").querySelector("input")).not.toBeChecked();
     expect(tag3.closest("label").querySelector("input")).not.toBeChecked();
     expect(tag4.closest("label").querySelector("input")).not.toBeChecked();
+    expect(tag5.closest("label").querySelector("input")).not.toBeChecked();
 
     fireEvent.click(tag1);
     expect(tag1.closest("label").querySelector("input")).toBeChecked();
     expect(tag2.closest("label").querySelector("input")).not.toBeChecked();
     expect(tag3.closest("label").querySelector("input")).not.toBeChecked();
     expect(tag4.closest("label").querySelector("input")).not.toBeChecked();
+    expect(tag5.closest("label").querySelector("input")).not.toBeChecked();
 
     fireEvent.click(tag2);
     expect(tag1.closest("label").querySelector("input")).not.toBeChecked();
     expect(tag2.closest("label").querySelector("input")).toBeChecked();
     expect(tag3.closest("label").querySelector("input")).not.toBeChecked();
     expect(tag4.closest("label").querySelector("input")).not.toBeChecked();
+    expect(tag5.closest("label").querySelector("input")).not.toBeChecked();
 
     fireEvent.click(tag3);
     expect(tag1.closest("label").querySelector("input")).not.toBeChecked();
     expect(tag2.closest("label").querySelector("input")).not.toBeChecked();
     expect(tag3.closest("label").querySelector("input")).toBeChecked();
     expect(tag4.closest("label").querySelector("input")).not.toBeChecked();
+    expect(tag5.closest("label").querySelector("input")).not.toBeChecked();
+
+    fireEvent.click(tag3);
+    expect(tag1.closest("label").querySelector("input")).not.toBeChecked();
+    expect(tag2.closest("label").querySelector("input")).not.toBeChecked();
+    expect(tag3.closest("label").querySelector("input")).not.toBeChecked();
+    expect(tag4.closest("label").querySelector("input")).not.toBeChecked();
+    expect(tag5.closest("label").querySelector("input")).not.toBeChecked();
   });
 });


### PR DESCRIPTION
## 변경사항

<!-- 변경사항을 간략히 기술합니다. -->

- 태그 정렬 시 카운터 기준 다음 한국어 기준으로 정렬한다

## 이슈

<!-- PR과 관련된 이슈 링크를 작성합니다. -->

- https://github.com/sogoagain/blog/issues/93

## 회고

<!-- PR을 회고합니다. -->

- [x] 코드를 다시 한번 살펴보았나요?
