### PR TITLE
[sogoagain/blog#114] Nostr 웹 클라이언트 링크를 nostter로 변경

### DIFF
--- a/src/components/notes/Note.jsx
+++ b/src/components/notes/Note.jsx
@@ -28,7 +28,7 @@ export default function Note({ note }) {
     defaultProtocol: "https",
     formatHref: (href, type) => {
       if (type === "hashtag") {
-        return `https://snort.social/t/${href.substring(1)}`;
+        return `https://nostter.app/search?q=${encodeURIComponent(href)}`;
       }
       return href;
     },

--- a/src/components/sections/Footer.test.jsx
+++ b/src/components/sections/Footer.test.jsx
@@ -17,7 +17,7 @@ describe("<Footer/>", () => {
     },
     {
       text: "Nostr",
-      href: `https://snort.social/p/1234`,
+      href: `https://nostter.app/1234`,
     },
   ];
 
@@ -36,7 +36,7 @@ describe("<Footer/>", () => {
     text        | link
     ${"Email"}  | ${`mailto:test@gmail.com`}
     ${"GitHub"} | ${`https://github.com/sogoagain`}
-    ${"Nostr"}  | ${`https://snort.social/p/1234`}
+    ${"Nostr"}  | ${`https://nostter.app/1234`}
   `("'$text'(으)로 이동하는 '$link'를 출력한다", ({ text, link }) => {
     const linkEl = screen.getByText(text);
 

--- a/src/container/FooterContainer.jsx
+++ b/src/container/FooterContainer.jsx
@@ -40,7 +40,7 @@ export default function FooterContainer() {
     },
     {
       text: "Nostr",
-      href: `https://snort.social/p/${social.nostr.nPubKey}`,
+      href: `https://nostter.app/${social.nostr.nPubKey}`,
     },
   ];
 

--- a/src/container/FooterContainer.test.jsx
+++ b/src/container/FooterContainer.test.jsx
@@ -28,7 +28,7 @@ describe("<FooterContainer/>", () => {
     text        | link
     ${"Email"}  | ${`mailto:sogoagain@sogoagain.com`}
     ${"GitHub"} | ${`https://github.com/sogoagain`}
-    ${"Nostr"}  | ${`https://snort.social/p/npub1nhffp7hfyy2weckcw7tslaf20qhk7dp59zal2swghx4tpc9ejjxsuqxcf8`}
+    ${"Nostr"}  | ${`https://nostter.app/npub1nhffp7hfyy2weckcw7tslaf20qhk7dp59zal2swghx4tpc9ejjxsuqxcf8`}
   `("'$text'(으)로 이동하는 '$link'를 출력한다", ({ text, link }) => {
     const linkEl = screen.getByText(text);
 

--- a/src/pages/notes.jsx
+++ b/src/pages/notes.jsx
@@ -26,7 +26,7 @@ export default function NotePage({
       <h1>노트</h1>
       <p>
         <strong>
-          from <Anchor href={`https://snort.social/p/${nPubKey}`}>Nostr</Anchor>
+          from <Anchor href={`https://nostter.app/${nPubKey}`}>Nostr</Anchor>
         </strong>
       </p>
       <NostrContainer />


### PR DESCRIPTION
## 변경사항

<!-- 변경사항을 간략히 기술합니다. -->

- Nostr 웹 클라이언트 링크를 nostter로 변경한다.

## 이슈

<!-- PR과 관련된 이슈 링크를 작성합니다. -->

- https://github.com/sogoagain/blog/issues/114

## 회고

<!-- PR을 회고합니다. -->

- [x] 코드를 다시 한번 살펴보았나요?
