### PR TITLE
[sogoagain/blog#135] CD 워크플로우 `id-token` 권한 명시

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,6 +15,9 @@ defaults:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## 변경사항

<!-- 변경사항을 간략히 기술합니다. -->

- CD 워크플로우에 배포를 위해 `id-token` 권한을 명시합니다.

## 이슈

<!-- PR과 관련된 이슈 링크를 작성합니다. -->

- https://github.com/sogoagain/blog/issues/135

## 회고

<!-- PR을 회고합니다. -->

- [x] 코드를 다시 한번 살펴보았나요?
