### PR TITLE
[sogoagain/blog#149] 노트 - 해시태그 목록을 노트 갯수 기준으로 정렬한다

### DIFF
--- a/__mocks__/nostr-tools.js
+++ b/__mocks__/nostr-tools.js
@@ -60,6 +60,27 @@ module.exports = {
             ["expiration", "1692845589"],
           ],
         });
+        callbacks.onevent({
+          id: "id9",
+          kind: 1,
+          content: "노트 4 #Zaps",
+          created_at: 1705515813,
+          tags: [],
+        });
+        callbacks.onevent({
+          id: "id10",
+          kind: 1,
+          content: "노트 5 #Bitcoin",
+          created_at: 1706465813,
+          tags: [],
+        });
+        callbacks.onevent({
+          id: "id11",
+          kind: 1,
+          content: "노트 6 #테스트",
+          created_at: 1707465813,
+          tags: [],
+        });
       }),
   })),
 };

--- a/src/container/NotesHashtagListContainer.jsx
+++ b/src/container/NotesHashtagListContainer.jsx
@@ -10,9 +10,15 @@ export default function NotesHashtagListContainer() {
   const dispatch = useDispatch();
   const { hashtags, selectedHashtag } = useSelector((state) => state.nostr);
 
-  const tags = Object.keys(hashtags)
-    .filter((hashtag) => hashtag !== "ETC")
-    .sort();
+  const tags = Object.entries(hashtags)
+    .filter(([hashtag]) => hashtag !== "ETC")
+    .sort(([aHashtag, aIds], [bHashtag, bIds]) => {
+      const totalCountDiff = bIds.length - aIds.length;
+      return totalCountDiff === 0
+        ? aHashtag.localeCompare(bHashtag, "ko")
+        : totalCountDiff;
+    })
+    .map(([hashtag]) => hashtag);
 
   if (hashtags.ETC) {
     tags.push("ETC");

--- a/src/pages/notes.test.jsx
+++ b/src/pages/notes.test.jsx
@@ -47,6 +47,17 @@ describe("<NotePage/>", () => {
     });
   });
 
+  it("해시태그 목록이 노트 갯수를 기준으로 내림차순, 노트 갯수가 동일하면 한국어 기준 정렬되어 출력된다", () => {
+    const labels = screen
+      .getAllByText(/(BITCOIN|NOTHING|ZAPS|ETC|테스트)/)
+      .map((label) => label.textContent)
+      .filter((text) => !text.startsWith("#"));
+
+    const sortedHashtags = ["ZAPS", "테스트", "BITCOIN", "NOTHING", "ETC"];
+
+    expect(labels).toEqual(sortedHashtags);
+  });
+
   it("노트 목록을 출력한다", () => {
     const note1 = screen.getByText("노트 1");
     const note1Date = screen.getByText("2023-12-24");
@@ -85,7 +96,7 @@ describe("<NotePage/>", () => {
 
     const items = screen.getAllByRole("listitem");
 
-    expect(items).toHaveLength(3);
+    expect(items).toHaveLength(6);
   });
 
   it("ETC 해시태그 필터를 선택하면 태그가 없는 노트를 출력한다", () => {
@@ -104,10 +115,10 @@ describe("<NotePage/>", () => {
     expect(img).toBeInTheDocument();
   });
 
-  it("노트만 출력한다", () => {
+  it("노트들을 출력한다", () => {
     const noteEls = screen.getAllByRole("listitem");
 
-    expect(noteEls).toHaveLength(3);
+    expect(noteEls).toHaveLength(6);
   });
 
   it("footer를 출력한다", () => {


### PR DESCRIPTION
## 변경사항

<!-- 변경사항을 간략히 기술합니다. -->

- 해시태그 목록을 노트 갯수 기준으로 정렬하여 출력한다.

## 이슈

<!-- PR과 관련된 이슈 링크를 작성합니다. -->

- https://github.com/sogoagain/blog/issues/149

## 회고

<!-- PR을 회고합니다. -->

- [ ] 코드를 다시 한번 살펴보았나요?
