### PR TITLE
[sogoagain/blog#185] 노트를 최신 작성일 순으로 정렬하여 출력한다

### DIFF
--- a/src/container/NotesContainer.jsx
+++ b/src/container/NotesContainer.jsx
@@ -16,7 +16,7 @@ export default function NotesContainer() {
 
   const ownerNotes = notes
     .map((note) => textNote[note])
-    .sort((a, b) => a.create_at - b.create_at);
+    .sort((a, b) => b.created_at - a.created_at);
 
   const filteredNotes = selected
     ? ownerNotes.filter((note) => tags[selected].includes(note.id))

--- a/src/pages/notes.test.jsx
+++ b/src/pages/notes.test.jsx
@@ -168,10 +168,27 @@ describe("<NotePage/>", () => {
     });
   });
 
-  it("노트들을 출력한다", () => {
+  it("노트들을 생성일 기준으로 정렬한 뒤 출력한다", () => {
     const noteEls = screen.getAllByRole("listitem");
 
     expect(noteEls).toHaveLength(9);
+    expect(noteEls[0].textContent).toEqual(
+      "2023-12-24노트 1 https://blog.sogoagain.com/ #Nothing",
+    );
+    expect(noteEls[1].textContent).toEqual("2024-01-05노트 2 #Zaps");
+    expect(noteEls[2].textContent).toEqual("2024-01-06노트 3 ");
+    expect(noteEls[3].textContent).toEqual("2024-01-17노트 4  #Zaps");
+    expect(noteEls[4].textContent).toEqual("2024-01-28노트 5 #Bitcoin");
+    expect(noteEls[5].textContent).toEqual("2024-02-09노트 6 #테스트");
+    expect(noteEls[6].textContent).toContain(
+      "2024-02-24@npub1zatgwjy 조회하지 못한 멘션과 인용",
+    );
+    expect(noteEls[7].textContent).toEqual(
+      "2024-02-24@mockusername2 멘션된 프로필을 조회한 노트",
+    );
+    expect(noteEls[8].textContent).toContain(
+      "2024-02-24인용된 노트를 조회한 노트",
+    );
   });
 
   it("footer를 출력한다", () => {

--- a/src/pages/notes.test.jsx
+++ b/src/pages/notes.test.jsx
@@ -172,22 +172,22 @@ describe("<NotePage/>", () => {
     const noteEls = screen.getAllByRole("listitem");
 
     expect(noteEls).toHaveLength(9);
-    expect(noteEls[0].textContent).toEqual(
-      "2023-12-24노트 1 https://blog.sogoagain.com/ #Nothing",
-    );
-    expect(noteEls[1].textContent).toEqual("2024-01-05노트 2 #Zaps");
-    expect(noteEls[2].textContent).toEqual("2024-01-06노트 3 ");
-    expect(noteEls[3].textContent).toEqual("2024-01-17노트 4  #Zaps");
-    expect(noteEls[4].textContent).toEqual("2024-01-28노트 5 #Bitcoin");
-    expect(noteEls[5].textContent).toEqual("2024-02-09노트 6 #테스트");
-    expect(noteEls[6].textContent).toContain(
+    expect(noteEls[0].textContent).toContain(
       "2024-02-24@npub1zatgwjy 조회하지 못한 멘션과 인용",
     );
-    expect(noteEls[7].textContent).toEqual(
+    expect(noteEls[1].textContent).toEqual(
       "2024-02-24@mockusername2 멘션된 프로필을 조회한 노트",
     );
-    expect(noteEls[8].textContent).toContain(
+    expect(noteEls[2].textContent).toContain(
       "2024-02-24인용된 노트를 조회한 노트",
+    );
+    expect(noteEls[3].textContent).toEqual("2024-02-09노트 6 #테스트");
+    expect(noteEls[4].textContent).toEqual("2024-01-28노트 5 #Bitcoin");
+    expect(noteEls[5].textContent).toEqual("2024-01-17노트 4  #Zaps");
+    expect(noteEls[6].textContent).toEqual("2024-01-06노트 3 ");
+    expect(noteEls[7].textContent).toEqual("2024-01-05노트 2 #Zaps");
+    expect(noteEls[8].textContent).toEqual(
+      "2023-12-24노트 1 https://blog.sogoagain.com/ #Nothing",
     );
   });
 


### PR DESCRIPTION
## 변경사항

<!-- 변경사항을 간략히 기술합니다. -->

- 작성된 노트를 최신순으로 정렬하여 출력하는 로직에 버그가 있어 이를 수정합니다.

## 이슈

<!-- PR과 관련된 이슈 링크를 작성합니다. -->

- https://github.com/sogoagain/blog/issues/185

## 회고

<!-- PR을 회고합니다. -->

- [x] 코드를 다시 한번 살펴보았나요?
