### PR TITLE
[sogoagain/blog#206] 노트 - 릴레이 타임아웃 개선

### DIFF
--- a/src/features/nostrSlice.js
+++ b/src/features/nostrSlice.js
@@ -218,7 +218,7 @@ const handleOwnerEvent = (event) =>
     },
   })[event.kind] || (() => {});
 
-function subscribeEvents(relays, filters, onEvent, eoseTimeout = 60000) {
+function subscribeEvents(relays, filters, onEvent, eoseTimeout = 10000) {
   return (dispatch, getState) => {
     const completedRelays = new Set();
 


### PR DESCRIPTION
## 변경사항

<!-- 변경사항을 간략히 기술합니다. -->

- 릴레이 구독 시 `eoseTimeout`을 1분에서 10초로 최적화합니다.

## 이슈

<!-- PR과 관련된 이슈 링크를 작성합니다. -->

- https://github.com/sogoagain/blog/issues/206

## 회고

<!-- PR을 회고합니다. -->

- [x] 코드를 다시 한번 살펴보았나요?
